### PR TITLE
Modified Types in Grass Layer

### DIFF
--- a/earth/cpu_intr.c
+++ b/earth/cpu_intr.c
@@ -12,12 +12,12 @@
 /* These are two static variables storing
  * the addresses of the handler functions;
  * Initially, both variables are NULL */
-static void (*intr_handler)(int);
-static void (*excp_handler)(int);
+static void (*intr_handler)(uint);
+static void (*excp_handler)(uint);
 
 /* Register handler functions by modifying the static variables */
-int intr_register(void (*_handler)(int)) { intr_handler = _handler; }
-int excp_register(void (*_handler)(int)) { excp_handler = _handler; }
+int intr_register(void (*_handler)(uint)) { intr_handler = _handler; }
+int excp_register(void (*_handler)(uint)) { excp_handler = _handler; }
 
 void trap_entry_vm(); /* This wrapper function is defined in earth.S */
 void trap_entry()  __attribute__((interrupt ("machine"), aligned(128)));

--- a/grass/process.c
+++ b/grass/process.c
@@ -12,7 +12,7 @@
 #include "syscall.h"
 #include <string.h>
 
-static void proc_set_status(int pid, int status) {
+static void proc_set_status(int pid, enum proc_status status) {
     for (int i = 0; i < MAX_NPROCESS; i++)
         if (proc_set[i].pid == pid) proc_set[i].status = status;
 }
@@ -22,8 +22,8 @@ void proc_set_running(int pid) { proc_set_status(pid, PROC_RUNNING); }
 void proc_set_runnable(int pid) { proc_set_status(pid, PROC_RUNNABLE); }
 
 int proc_alloc() {
-    static int proc_nprocs = 0;
-    for (int i = 0; i < MAX_NPROCESS; i++)
+    static uint proc_nprocs = 0;
+    for (uint i = 0; i < MAX_NPROCESS; i++)
         if (proc_set[i].status == PROC_UNUSED) {
             proc_set[i].pid = ++proc_nprocs;
             proc_set[i].status = PROC_LOADING;
@@ -41,7 +41,7 @@ void proc_free(int pid) {
     }
 
     /* Free all user applications */
-    for (int i = 0; i < MAX_NPROCESS; i++)
+    for (uint i = 0; i < MAX_NPROCESS; i++)
         if (proc_set[i].pid >= GPID_USER_START &&
             proc_set[i].status != PROC_UNUSED) {
             earth->mmu_free(proc_set[i].pid);

--- a/grass/process.h
+++ b/grass/process.h
@@ -3,7 +3,7 @@
 #include "elf.h"
 #include "disk.h"
 
-enum {
+enum proc_status {
     PROC_UNUSED,
     PROC_LOADING, /* allocated and wait for loading elf binary */
     PROC_READY,   /* finished loading elf and wait for first running */
@@ -15,20 +15,20 @@ enum {
 
 struct process{
     int pid;
-    int status;
+    enum proc_status status;
     int receiver_pid; /* used when waiting to send a message */
     void *sp, *mepc;  /* process context = stack pointer (sp)
                        * + machine exception program counter (mepc) */
 };
 
 #define MAX_NPROCESS  16
-extern int proc_curr_idx;
+extern uint proc_curr_idx;
 extern struct process proc_set[MAX_NPROCESS];
 #define curr_pid      proc_set[proc_curr_idx].pid
 #define curr_status   proc_set[proc_curr_idx].status
 
-void intr_entry(int);
-void excp_entry(int);
+void intr_entry(uint);
+void excp_entry(uint);
 
 int  proc_alloc();
 void proc_free(int);

--- a/grass/syscall.c
+++ b/grass/syscall.c
@@ -20,7 +20,7 @@ static void sys_invoke() {
     while (sc->type != SYS_UNUSED);
 }
 
-int sys_send(int receiver, char* msg, int size) {
+int sys_send(int receiver, char* msg, uint size) {
     if (size > SYSCALL_MSG_LEN) return -1;
 
     sc->type = SYS_SEND;
@@ -30,7 +30,7 @@ int sys_send(int receiver, char* msg, int size) {
     return sc->retval;    
 }
 
-int sys_recv(int* sender, char* buf, int size) {
+int sys_recv(int* sender, char* buf, uint size) {
     if (size > SYSCALL_MSG_LEN) return -1;
 
     sc->type = SYS_RECV;

--- a/grass/syscall.h
+++ b/grass/syscall.h
@@ -22,5 +22,5 @@ struct syscall {
 };
 
 void sys_exit(int status);
-int  sys_send(int pid, char* msg, int size);
-int  sys_recv(int* pid, char* buf, int size);
+int  sys_send(int pid, char* msg, uint size);
+int  sys_recv(int* pid, char* buf, uint size);

--- a/library/egos.h
+++ b/library/egos.h
@@ -1,11 +1,14 @@
 #pragma once
 
+typedef unsigned int uint;
+typedef unsigned short int ushort;
+
 struct earth {
     /* CPU interface */
     int (*timer_reset)();
 
-    int (*intr_register)(void (*handler)(int));
-    int (*excp_register)(void (*handler)(int));
+    int (*intr_register)(void (*handler)(uint));
+    int (*excp_register)(void (*handler)(uint));
 
     int (*mmu_alloc)(int* frame_no, void** cached_addr);
     int (*mmu_free)(int pid);
@@ -43,8 +46,8 @@ struct grass {
 
     /* System call interface */
     void (*sys_exit)(int status);
-    int  (*sys_send)(int pid, char* msg, int size);
-    int  (*sys_recv)(int* pid, char* buf, int size);
+    int  (*sys_send)(int pid, char* msg, uint size);
+    int  (*sys_recv)(int* pid, char* buf, uint size);
 };
 
 extern struct earth *earth;
@@ -81,6 +84,3 @@ extern struct grass *grass;
 #define ACCESS(x) (*(__typeof__(*x) volatile *)(x))
 #define REGW(base, offset) (ACCESS((unsigned int*)(base + offset)))
 #define REGB(base, offset) (ACCESS((unsigned char*)(base + offset)))
-
-typedef unsigned int uint;
-typedef unsigned short int ushort;


### PR DESCRIPTION
- Updated Types to UInt at Proper Places
- Modified Process Control Block status To Use proc_status enum
- Changed Variables Using enum to Designated enum Type


I was not fully sure about whether pid, sender, and receiver should use unsigned int types, but it seemed that they may hold -1 at certain points.