### PR TITLE
earth/cpu_mmu: add ability to flush tlb cache

### DIFF
--- a/earth/cpu_mmu.c
+++ b/earth/cpu_mmu.c
@@ -24,11 +24,6 @@ struct page_info {
 #define PAGE_NO_TO_ADDR(x) (char*)(x * PAGE_SIZE)
 #define PAGE_ID_TO_ADDR(x) (char*)APPS_PAGES_BASE + x * PAGE_SIZE
 
-void flush_tlb_cache() {
-    /*  See https://riscv.org/wp-content/uploads/2017/05/riscv-privileged-v1.10.pdf#subsection.4.2.1 */
-    asm("sfence.vma zero,zero");
-}
-
 void mmu_alloc(uint* ppage_id, void** ppage_addr) {
     for (uint i = 0; i < APPS_PAGES_CNT; i++)
         if (!page_info_table[i].use) {
@@ -141,8 +136,6 @@ void pagetable_identity_mapping(int pid) {
 
         /* Student's code ends here. */
     }
-
-    flush_tlb_cache();
 }
 
 void page_table_map(int pid, uint vpage_no, uint ppage_id) {
@@ -160,12 +153,9 @@ void page_table_map(int pid, uint vpage_no, uint ppage_id) {
     soft_tlb_map(pid, vpage_no, ppage_id);
 
     /* Student's code ends here. */
-
-    flush_tlb_cache();
 }
 
 void page_table_switch(int pid) {
-    flush_tlb_cache();
     /* Student's code goes here (page table translation). */
 
     /* Remove the following line of code and, instead,
@@ -175,8 +165,6 @@ void page_table_switch(int pid) {
     soft_tlb_switch(pid);
 
     /* Student's code ends here. */
-
-    flush_tlb_cache();
 }
 
 void flush_cache() {
@@ -188,6 +176,8 @@ void flush_cache() {
             "nop\nnop\nnop\nnop\nnop\n"
         );
     }
+    /*  See https://riscv.org/wp-content/uploads/2017/05/riscv-privileged-v1.10.pdf#subsection.4.2.1 */
+    asm("sfence.vma zero,zero");
 }
 
 /* MMU Initialization */

--- a/earth/cpu_mmu.c
+++ b/earth/cpu_mmu.c
@@ -24,6 +24,11 @@ struct page_info {
 #define PAGE_NO_TO_ADDR(x) (char*)(x * PAGE_SIZE)
 #define PAGE_ID_TO_ADDR(x) (char*)APPS_PAGES_BASE + x * PAGE_SIZE
 
+void flush_tlb_cache() {
+    /*  See https://riscv.org/wp-content/uploads/2017/05/riscv-privileged-v1.10.pdf#subsection.4.2.1 */
+    asm("sfence.vma zero,zero");
+}
+
 void mmu_alloc(uint* ppage_id, void** ppage_addr) {
     for (uint i = 0; i < APPS_PAGES_CNT; i++)
         if (!page_info_table[i].use) {
@@ -136,6 +141,8 @@ void pagetable_identity_mapping(int pid) {
 
         /* Student's code ends here. */
     }
+
+    flush_tlb_cache();
 }
 
 void page_table_map(int pid, uint vpage_no, uint ppage_id) {
@@ -153,9 +160,12 @@ void page_table_map(int pid, uint vpage_no, uint ppage_id) {
     soft_tlb_map(pid, vpage_no, ppage_id);
 
     /* Student's code ends here. */
+
+    flush_tlb_cache();
 }
 
 void page_table_switch(int pid) {
+    flush_tlb_cache();
     /* Student's code goes here (page table translation). */
 
     /* Remove the following line of code and, instead,
@@ -165,6 +175,8 @@ void page_table_switch(int pid) {
     soft_tlb_switch(pid);
 
     /* Student's code ends here. */
+
+    flush_tlb_cache();
 }
 
 void flush_cache() {

--- a/earth/cpu_mmu.c
+++ b/earth/cpu_mmu.c
@@ -176,8 +176,11 @@ void flush_cache() {
             "nop\nnop\nnop\nnop\nnop\n"
         );
     }
-    /*  See https://riscv.org/wp-content/uploads/2017/05/riscv-privileged-v1.10.pdf#subsection.4.2.1 */
-    asm("sfence.vma zero,zero");
+    if (earth->translation == PAGE_TABLE){
+      /* Flush the TLB, which is the cache of page table entries */
+      /* See https://riscv.org/wp-content/uploads/2017/05/riscv-privileged-v1.10.pdf#subsection.4.2.1 */
+      asm("sfence.vma zero,zero");
+    }
 }
 
 /* MMU Initialization */

--- a/grass/init.c
+++ b/grass/init.c
@@ -30,6 +30,7 @@ void grass_entry(uint core_id) {
     elf_load(GPID_PROCESS, sys_proc_read, 0, 0);
     proc_set_running(proc_alloc());
     earth->mmu_switch(GPID_PROCESS);
+    earth->mmu_flush_cache();
 
     /* Set other cores to idle */
     for (uint i = 0; i < NCORES; i++)

--- a/grass/kernel.c
+++ b/grass/kernel.c
@@ -151,8 +151,9 @@ static int proc_try_send(struct process* sender) {
 
 static int proc_try_recv(struct process* receiver) {
     if (receiver->syscall.msg.status == PENDING) return -1;
-    
+
     earth->mmu_switch(receiver->pid);
+    earth->mmu_flush_cache();
     memcpy((void*)SYSCALL_ARG, &receiver->syscall, sizeof(struct syscall));
     return 0;
 }


### PR DESCRIPTION
As per [RISC V's documentation](https://riscv.org/wp-content/uploads/2017/05/riscv-privileged-v1.10.pdf#subsection.4.2.1), the `sfence.vma` command is needed when
updating the in-memory data structures for page tables. This change adds this enhancement to prevent bugs when implementing virtual memory.

Manual Testing:
-  This change has been present in NU's egos and has been working with QEMU for a while
-  Tested the change on the Arty A7 35T board.
-  Tested the change on QEMU.


