### PR TITLE
 Add comments and helpers for Pagetable translation project

### DIFF
--- a/earth/cpu_mmu.c
+++ b/earth/cpu_mmu.c
@@ -82,7 +82,6 @@ void soft_tlb_switch(int pid) {
 #define OS_RWX         (0xC0 | 0xF)
 #define USER_RWX       (0xC0 | 0x1F)
 #define MAX_NPROCESS   256
-#define USER_PID_START 5
 static uint* root;
 static uint* leaf;
 static uint* pid_to_pagetable_base[MAX_NPROCESS];
@@ -146,10 +145,9 @@ void page_table_map(int pid, uint vpage_no, uint ppage_id) {
 
     /* Remove the following line of code and, instead,
      * (1) if page tables for pid do not exist, build the tables:
-     *  (a) If the process is a system process (pid < USER_PID_START) (QEMU and ARTY)
+     *  (a) If the process is a system process (pid < GPID_USER_START) (QEMU and ARTY)
      *      | Start Address | # Pages | Size   | Explanation                        |
      *      +---------------+---------+--------+------------------------------------+
-     *      | 0x08000000    | 512     | 2 MB   | Earth data, Grass code + data      |
      *      | 0x20400000    | 1024    | 4 MB   | Board Flash ROM                    |
      *      | 0x80000000    | 512     | 2 MB   | RAM start (Egos code + data)       |
      *      | 0x80200000    | 1       | 4 KB   | Earth struct                       |
@@ -163,11 +161,10 @@ void page_table_map(int pid, uint vpage_no, uint ppage_id) {
      *  (b) If the process is a user process (QEMU and ARTY)
      *      | Start Address | # Pages | Size   | Explanation                        |
      *      +---------------+---------+--------+------------------------------------+
-     *      | 0x08000000    | 512     | 2 MB   | Earth data, Grass code + data      |
      *      | 0x80000000    | 512     | 2 MB   | RAM start (Egos code + data)       |
-     *      | 0x80400000    | 512     | 2 MB   | Egos stack                         |
      *      | 0x80200000    | 1       | 4 KB   | Earth struct                       |
      *      | 0x80201000    | 1       | 4 KB   | Grass struct                       |
+     *      | 0x80400000    | 512     | 2 MB   | Egos stack                         |
      *      | 0x80800000    | 512     | 2 MB   | App stack and base                 |
      *
      * (2) if page tables for pid exist, find the PTE and  update entries of the tables

--- a/earth/cpu_mmu.c
+++ b/earth/cpu_mmu.c
@@ -79,9 +79,10 @@ void soft_tlb_switch(int pid) {
  * tables and mmu_switch() will modify satp (page table base register)
  */
 
-#define OS_RWX       (0xC0 | 0xF)
-#define USER_RWX     (0xC0 | 0x1F)
-#define MAX_NPROCESS 256
+#define OS_RWX         (0xC0 | 0xF)
+#define USER_RWX       (0xC0 | 0x1F)
+#define MAX_NPROCESS   256
+#define USER_PID_START 5
 static uint* root;
 static uint* leaf;
 static uint* pid_to_pagetable_base[MAX_NPROCESS];
@@ -144,9 +145,32 @@ void page_table_map(int pid, uint vpage_no, uint ppage_id) {
     /* Student's code goes here (page table translation). */
 
     /* Remove the following line of code and, instead,
-     * (1) if page tables for pid do not exist, build the tables;
-     * (2) if page tables for pid exist, update entries of the tables
+     * (1) if page tables for pid do not exist, build the tables:
+     *  (a) If the process is a system process (pid < USER_PID_START) (QEMU and ARTY)
+     *      | Start Address | # Pages | Size   | Explanation                        |
+     *      +---------------+---------+--------+------------------------------------+
+     *      | 0x08000000    | 512     | 2 MB   | Earth data, Grass code + data      |
+     *      | 0x20400000    | 1024    | 4 MB   | Board Flash ROM                    |
+     *      | 0x80000000    | 512     | 2 MB   | RAM start (Egos code + data)       |
+     *      | 0x80200000    | 1       | 4 KB   | Earth struct                       |
+     *      | 0x80201000    | 1       | 4 KB   | Grass struct                       |
+     *      | 0x80400000    | 512     | 2 MB   | Egos stack                         |
+     *      | 0x80600000    | 1       | 4 KB   | Apps argc/argv                     |
+     *      | 0x80601000    | 1       | 4 KB   | Syscall arg struct                 |
+     *      | 0x80800000    | 512     | 2 MB   | App stack and base                 |
      *
+     *
+     *  (b) If the process is a user process (QEMU and ARTY)
+     *      | Start Address | # Pages | Size   | Explanation                        |
+     *      +---------------+---------+--------+------------------------------------+
+     *      | 0x08000000    | 512     | 2 MB   | Earth data, Grass code + data      |
+     *      | 0x80000000    | 512     | 2 MB   | RAM start (Egos code + data)       |
+     *      | 0x80400000    | 512     | 2 MB   | Egos stack                         |
+     *      | 0x80200000    | 1       | 4 KB   | Earth struct                       |
+     *      | 0x80201000    | 1       | 4 KB   | Grass struct                       |
+     *      | 0x80800000    | 512     | 2 MB   | App stack and base                 |
+     *
+     * (2) if page tables for pid exist, find the PTE and  update entries of the tables
      * Feel free to modify and call the two helper functions:
      * pagetable_identity_mapping() and setup_identity_region()
      */

--- a/grass/kernel.c
+++ b/grass/kernel.c
@@ -142,11 +142,6 @@ static int proc_try_send(struct process* sender) {
 
             dst->syscall.msg.status = RECEIVED;
             dst->syscall.msg.sender = sender->pid;
-          /* Student's code goes here (page table translation)
-           * sender->syscall's address space belongs to sender->pid's address space,
-           * In this case it needs to be translated to the dst->pid's address space
-           * before the message can be copied.
-           */
             memcpy(dst->syscall.msg.content, sender->syscall.msg.content, SYSCALL_MSG_LEN);
             return 0;
         }
@@ -157,11 +152,6 @@ static int proc_try_send(struct process* sender) {
 static int proc_try_recv(struct process* receiver) {
     if (receiver->syscall.msg.status == PENDING) return -1;
 
-    /* Student's code goes here (page table translatiion)
-     * receiver->syscall's address space belongs to receiver->pid's address space,
-     * In this case it needs to be translated to the kernel's address space before
-     * the message can be copied to SYSCALL_ARG.
-     */
     earth->mmu_switch(receiver->pid);
     earth->mmu_flush_cache();
     memcpy((void*)SYSCALL_ARG, &receiver->syscall, sizeof(struct syscall));

--- a/grass/kernel.c
+++ b/grass/kernel.c
@@ -142,6 +142,11 @@ static int proc_try_send(struct process* sender) {
 
             dst->syscall.msg.status = RECEIVED;
             dst->syscall.msg.sender = sender->pid;
+          /* Student's code goes here (page table translation)
+           * sender->syscall's address space belongs to sender->pid's address space,
+           * In this case it needs to be translated to the dst->pid's address space
+           * before the message can be copied.
+           */
             memcpy(dst->syscall.msg.content, sender->syscall.msg.content, SYSCALL_MSG_LEN);
             return 0;
         }
@@ -152,6 +157,11 @@ static int proc_try_send(struct process* sender) {
 static int proc_try_recv(struct process* receiver) {
     if (receiver->syscall.msg.status == PENDING) return -1;
 
+    /* Student's code goes here (page table translatiion)
+     * receiver->syscall's address space belongs to receiver->pid's address space,
+     * In this case it needs to be translated to the kernel's address space before
+     * the message can be copied to SYSCALL_ARG.
+     */
     earth->mmu_switch(receiver->pid);
     earth->mmu_flush_cache();
     memcpy((void*)SYSCALL_ARG, &receiver->syscall, sizeof(struct syscall));


### PR DESCRIPTION
This PR introduces comments and helper functions from Northeastern University's version of Virtual Memory. However, the `void* (*mmu_translate)(int pid, void *va)` parameter of earth, which translates virtual addresses (VA) to physical addresses (PA) for Earth, is currently missing from egos.h.

Please let me know if this is better explained in the handout, or if it should be directly integrated into the code.

Handout reference: [Lab 5 Handout](https://naizhengtan.github.io/23fall/labtutorials/lab5/)