### PR TITLE
Premptive Scheduler: add additional hints in comments.

### DIFF
--- a/earth/cpu_intr.c
+++ b/earth/cpu_intr.c
@@ -43,8 +43,7 @@ void intr_init(uint core_id) {
 
     /* Student's code goes here (preemptive scheduler)
      * Add an interface function timer_read in struct earth for reading the
-     * mtime register. And initialize timer_read here.
-     * */
+     * mtime register. And initialize timer_read here. */
 
     /* Student's code ends here. */
 

--- a/earth/cpu_intr.c
+++ b/earth/cpu_intr.c
@@ -41,7 +41,10 @@ void intr_init(uint core_id) {
     earth->timer_reset = timer_reset;
     mtimecmp_set(0x0FFFFFFFFFFFFFFFUL, core_id);
 
-    /* Student's code goes here (preemptive scheduler)*/
+    /* Student's code goes here (preemptive scheduler)
+     * Add an interface function timer_read in struct earth for reading the
+     * mtime register. And initialize timer_read here.
+     * */
 
     /* Student's code ends here. */
 

--- a/grass/kernel.c
+++ b/grass/kernel.c
@@ -87,10 +87,10 @@ static void proc_yield() {
     /* Set the current process status to RUNNABLE if it was RUNNING */
     if (!CORE_IDLE && curr_status == PROC_RUNNING) proc_set_runnable(curr_pid);
 
-  /* Student's code goes here (preemptive scheduler)
-   * Capture current process's info before it is scheduled out.
-   * Replace the loop to find the next process with your sheduler logic.
-   * */
+    /* Student's code goes here (preemptive scheduler)
+     * Measure and record scheduling metrics for the current process before it yields.
+     * Replace the loop to find the next process with your sheduler logic. */
+
     /* Find the next process to run */
     int next_idx = MAX_NPROCESS;
     for (uint i = 1; i <= MAX_NPROCESS; i++) {
@@ -121,7 +121,7 @@ static void proc_yield() {
     earth->mmu_flush_cache();
 
     /* Student's code goes here (preemptive scheduler)
-     * Update the new process's scheduling information. */
+     * Measure and record scheduling metrics for the next process. */
 
     /* Student's code ends here. */
 

--- a/grass/kernel.c
+++ b/grass/kernel.c
@@ -88,7 +88,6 @@ static void proc_yield() {
     if (!CORE_IDLE && curr_status == PROC_RUNNING) proc_set_runnable(curr_pid);
 
     /* Student's code goes here (preemptive scheduler)
-     * Measure and record scheduling metrics for the current process before it yields.
      * Replace the loop to find the next process with your sheduler logic. */
 
     /* Find the next process to run */
@@ -102,6 +101,9 @@ static void proc_yield() {
             break;
         }
     }
+
+    /* Measure and record scheduling metrics for the current process before it
+     * yields. */
 
     /* Student's code ends here*/
 

--- a/grass/kernel.c
+++ b/grass/kernel.c
@@ -87,6 +87,10 @@ static void proc_yield() {
     /* Set the current process status to RUNNABLE if it was RUNNING */
     if (!CORE_IDLE && curr_status == PROC_RUNNING) proc_set_runnable(curr_pid);
 
+  /* Student's code goes here (preemptive scheduler)
+   * Capture current process's info before it is scheduled out.
+   * Replace the loop to find the next process with your sheduler logic.
+   * */
     /* Find the next process to run */
     int next_idx = MAX_NPROCESS;
     for (uint i = 1; i <= MAX_NPROCESS; i++) {
@@ -98,6 +102,8 @@ static void proc_yield() {
             break;
         }
     }
+
+    /* Student's code ends here*/
 
     /* Context switch */
     curr_proc_idx = next_idx;
@@ -113,6 +119,11 @@ static void proc_yield() {
     }
     earth->mmu_switch(curr_pid);
     earth->mmu_flush_cache();
+
+    /* Student's code goes here (preemptive scheduler)
+     * Update the new process's scheduling information. */
+
+    /* Student's code ends here. */
 
     /* Student's code goes here (PMP, page table translation, and multi-core). */
 

--- a/grass/kernel.c
+++ b/grass/kernel.c
@@ -103,7 +103,7 @@ static void proc_yield() {
     }
 
     /* Measure and record scheduling metrics for the current process before it
-     * yields. */
+     * yields; Measure and record scheduling metrics for the next process. */
 
     /* Student's code ends here*/
 
@@ -121,11 +121,6 @@ static void proc_yield() {
     }
     earth->mmu_switch(curr_pid);
     earth->mmu_flush_cache();
-
-    /* Student's code goes here (preemptive scheduler)
-     * Measure and record scheduling metrics for the next process. */
-
-    /* Student's code ends here. */
 
     /* Student's code goes here (PMP, page table translation, and multi-core). */
 


### PR DESCRIPTION
This change adds additional hints in `proc_yield()` and `cpu_intr.c` to help implementing P2.