### PR TITLE
Add -fno-builtin to remove linker warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ OBJDUMP     = riscv-none-elf-objdump
 OBJCOPY     = riscv-none-elf-objcopy
 
 LDFLAGS     = -nostdlib -lc -lgcc
-CFLAGS      = -march=rv32ima_zicsr -mabi=ilp32 -Wl,--gc-sections -ffunction-sections -fdata-sections -fdiagnostics-show-option
+CFLAGS      = -march=rv32ima_zicsr -mabi=ilp32 -Wl,--gc-sections -ffunction-sections -fdata-sections -fdiagnostics-show-option -fno-builtin
 DEBUG_FLAGS = --source --all-headers --demangle --line-numbers --wide
 
 all:


### PR DESCRIPTION
Adding -fno-builtin to CFLAGS in the Makefile removes linker warnings regarding `printf()` usage.

When calling `printf()` with only the string argument and without carriage returns (not completely sure why...), the compiler will automatically try to inline its own function calls into main based on the standard library version of `printf()`, in which the compiler will call `puts()` instead of `printf()`.

Here is a [link](https://developer.arm.com/documentation/dui0774/l/Compiler-Command-line-Options/-fno-builtin) that describes this phenomenon

