### PR TITLE
Fix ANSI CSI interpretation on Linux/Bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,33 +40,33 @@ USRAPP_ELFS = $(patsubst %.c, $(RELEASE)/user/%.elf, $(notdir $(wildcard apps/us
 egos: $(USRAPP_ELFS) $(SYSAPP_ELFS) $(RELEASE)/egos.elf
 
 $(RELEASE)/egos.elf: $(EGOS_DEPS)
-	@echo "$(YELLOW)-------- Compile EGOS --------$(END)"
+	@printf "$(YELLOW)-------- Compile EGOS --------$(END)\n"
 	$(RISCV_CC) $(CFLAGS) $(INCLUDE) -DKERNEL $(filter %.s, $(wildcard $^)) $(filter %.c, $(wildcard $^)) -Tlibrary/elf/egos.lds $(LDFLAGS) -o $@
 	@$(OBJDUMP) $(DEBUG_FLAGS) $@ > $(DEBUG)/egos.lst
 
 $(SYSAPP_ELFS): $(RELEASE)/%.elf : apps/system/%.c $(APPS_DEPS)
-	@echo "Compile app$(CYAN)" $(patsubst %.c, %, $(notdir $<)) "$(END)=>" $@
+	@printf "Compile app $(CYAN)%s$(END) => %s\n" $(patsubst %.c, %, $(notdir $<)) $@
 	@$(RISCV_CC) $(CFLAGS) $(INCLUDE) -DFILESYS=$(FILESYS) -DKERNEL -Iapps apps/app.s $(filter %.c, $(wildcard $^)) -Tlibrary/elf/app.lds $(LDFLAGS) -o $@
 	@$(OBJDUMP) $(DEBUG_FLAGS) $@ > $(patsubst %.c, $(DEBUG)/%.lst, $(notdir $<))
 
 $(USRAPP_ELFS): $(RELEASE)/user/%.elf : apps/user/%.c $(APPS_DEPS)
 	@mkdir -p $(DEBUG) $(RELEASE) $(RELEASE)/user
-	@echo "Compile app$(CYAN)" $(patsubst %.c, %, $(notdir $<)) "$(END)=>" $@
+	@printf "Compile app $(CYAN)%s$(END) => %s\n" $(patsubst %.c, %, $(notdir $<)) $@
 	@$(RISCV_CC) $(CFLAGS) $(INCLUDE) -Iapps apps/app.s $(filter %.c, $(wildcard $^)) -Tlibrary/elf/app.lds $(LDFLAGS) -o $@
 	@$(OBJDUMP) $(DEBUG_FLAGS) $@ > $(patsubst %.c, $(DEBUG)/%.lst, $(notdir $<))
 
 install: egos
-	@echo "$(GREEN)-------- Create the Disk & BootROM Image --------$(END)"
+	@printf "$(GREEN)-------- Create the Disk & BootROM Image --------$(END)\n"
 	$(OBJCOPY) -O binary $(RELEASE)/egos.elf tools/qemu/egos.bin
 	$(CC) tools/mkfs.c library/file/file$(FILESYS).c -DMKFS -DFILESYS=$(FILESYS) -DCPU_BIN_FILE="\"fpga/vexriscv/vexriscv_$(BOARD)_$(NCORE)core.bin\"" $(INCLUDE) -o tools/mkfs
 	cd tools; rm -f disk.img bootROM.bin; ./mkfs
 
 qemu: install
-	@echo "$(YELLOW)-------- Simulate on QEMU-RISCV --------$(END)"
+	@printf "$(YELLOW)-------- Simulate on QEMU-RISCV --------$(END)\n"
 	$(QEMU) -nographic -readconfig tools/qemu/config.toml
 
 program: install
-	@echo "$(YELLOW)-------- Program the Arty $(BOARD) on-board ROM --------$(END)"
+	@printf "$(YELLOW)-------- Program the Arty $(BOARD) on-board ROM --------$(END)\n"
 	cd tools/fpga/openocd; time openocd -f 7series_$(BOARD).txt
 
 clean:


### PR DESCRIPTION
Hello,

Minor issue, which I traced down to the `echo` command failing to interpret ANSI CSI control characters for changing text properties in the output.

## Issue:
When issuing any of the `make` commands in my terminal, the ANSI CSI commands for changing text color, etc. are directly output to the screen instead of performing the text formatting operation (e.g. change color, make bold). Example:

```sh
% make
Compile app\033[1;36m cat \033[0m=> build/release/user/cat.elf
Compile app\033[1;36m cd \033[0m=> build/release/user/cd.elf
Compile app\033[1;36m crash1 \033[0m=> build/release/user/crash1.elf
Compile app\033[1;36m crash2 \033[0m=> build/release/user/crash2.elf
Compile app\033[1;36m echo \033[0m=> build/release/user/echo.elf
Compile app\033[1;36m loop \033[0m=> build/release/user/loop.elf
Compile app\033[1;36m ls \033[0m=> build/release/user/ls.elf
Compile app\033[1;36m udp_demo \033[0m=> build/release/user/udp_demo.elf
Compile app\033[1;36m vga_demo \033[0m=> build/release/user/vga_demo.elf
Compile app\033[1;36m sys_file \033[0m=> build/release/sys_file.elf
Compile app\033[1;36m sys_proc \033[0m=> build/release/sys_proc.elf
Compile app\033[1;36m sys_shell \033[0m=> build/release/sys_shell.elf
Compile app\033[1;36m sys_terminal \033[0m=> build/release/sys_terminal.elf
\033[1;33m-------- Compile EGOS --------\033[0m
riscv-none-elf-gcc -march=rv32ima_zicsr -mabi=ilp32 -Wl,--gc-sections -ffunction-sections -fdata-sections -fdiagnostics-show-option -Ilibrary -Ilibrary/elf -Ilibrary/file -Ilibrary/libc -Ilibrary/syscall -DKERNEL earth/boot.s grass/kernel.s earth/boot.c earth/cpu_intr.c earth/cpu_mmu.c earth/dev_disk.c earth/dev_tty.c grass/init.c grass/kernel.c grass/process.c library/elf/elf.c library/file/file0.c library/file/file1.c library/libc/malloc.c library/libc/print.c library/syscall/servers.c library/syscall/syscall.c -Tlibrary/elf/egos.lds -nostdlib -lc -lgcc -o build/release/egos.elf
```

I experienced the same whether using `tmux` or no, Alacritty (Bash), or Ghostty (Bash).

I confirmed issuing `printf` and even `echo -e` commands would properly interpret the escape sequences, but running the `make` commands always resulted in the escape sequences printed out instead of interpreted.

### My Environment:

![image](https://github.com/user-attachments/assets/f92494ba-0660-4c1e-9012-c64efc868632)

```sh
% which echo
/usr/bin/echo

% /usr/bin/echo --version
echo (GNU coreutils) 9.7
Copyright (C) 2025 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Brian Fox and Chet Ramey.

% /bin/echo --version
echo (GNU coreutils) 9.7
Copyright (C) 2025 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <https://gnu.org/licenses/gpl.html>.
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

Written by Brian Fox and Chet Ramey.

% uname -a
Linux zephy 6.15.2-zen1-1-zen #1 ZEN SMP PREEMPT_DYNAMIC Tue, 10 Jun 2025 21:32:14 +0000 x86_64 GNU/Linux

% lsb_release -a
LSB Version:    n/a
Distributor ID: Arch
Description:    Arch Linux
Release:        rolling
Codename:       n/a

% alacritty --version
alacritty 0.15.1 (0c405d53)

% bash --version
GNU bash, version 5.2.37(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.

 % cc --version
cc (GCC) 15.1.1 20250425
Copyright (C) 2025 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
```

# Resolution:

Given the uncertainty of using the `-e` flag on the `echo` command on other systems (Windows, MacOS, BSD, etc.), I did some research and it would appear that  using `printf` is a more acceptable cross-platform solution. **I have updated the Makefile to use the `printf` approach and can confirm it works on my environment as listed above.** It is also possible the `echo -e` option is equally viable, but it sounded like support for this flag may or may not exist, be ignored, or cause an error, depending on the system. I don't currently own a MacOS machine but I will try to get my Windows 11 PC set up to test the change and will report back on that to this PR.

I hope this helps! 

