### PR TITLE
Implement std=C99 for mkfs.c to fix errors on newer versions of GCC

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,61 +4,63 @@
 # BOARD can be a7_35t, a7_100t, or s7_50.
 # For a7_35t, NCORE can be 1 and this single core version supports VGA.
 # Due to hardware constraints, the 4-core version does not support VGA on a7_35t.
-BOARD       = a7_35t
-NCORE       = 4
-QEMU        = qemu-system-riscv32
+BOARD        = a7_35t
+NCORE        = 4
+QEMU         = qemu-system-riscv32
 
 ifeq ($(TOOLCHAIN), GNU)
 # Use the official GNU toolchain.
 # https://github.com/riscv-collab/riscv-gnu-toolchain
-RISCV_CC    = riscv32-unknown-elf-gcc
-OBJDUMP     = riscv32-unknown-elf-objdump
-OBJCOPY     = riscv32-unknown-elf-objcopy
+RISCV_CC     = riscv32-unknown-elf-gcc
+OBJDUMP      = riscv32-unknown-elf-objdump
+OBJCOPY      = riscv32-unknown-elf-objcopy
 else
 # Use the pre-compiled GNU toolchain binaries from xPack.
 # https://github.com/xpack-dev-tools/riscv-none-elf-gcc-xpack/releases
-RISCV_CC    = riscv-none-elf-gcc
-OBJDUMP     = riscv-none-elf-objdump
-OBJCOPY     = riscv-none-elf-objcopy
+RISCV_CC     = riscv-none-elf-gcc
+OBJDUMP      = riscv-none-elf-objdump
+OBJCOPY      = riscv-none-elf-objcopy
 endif
 
-DEBUG       = build/debug
-RELEASE     = build/release
+DEBUG        = build/debug
+RELEASE      = build/release
 
-APPS_DEPS   = apps/*.* library/egos.h library/*/* Makefile
-EGOS_DEPS   = earth/* grass/* library/egos.h library/*/* Makefile
+APPS_DEPS    = apps/*.* library/egos.h library/*/* Makefile
+EGOS_DEPS    = earth/* grass/* library/egos.h library/*/* Makefile
 
-FILESYS     = 1
-LDFLAGS     = -nostdlib -lc -lgcc
-INCLUDE     = -Ilibrary -Ilibrary/elf -Ilibrary/file -Ilibrary/libc -Ilibrary/syscall
-CFLAGS      = -march=rv32ima_zicsr -mabi=ilp32 -Wl,--gc-sections -ffunction-sections -fdata-sections -fdiagnostics-show-option
-DEBUG_FLAGS = --source --all-headers --demangle --line-numbers --wide
+FILESYS      = 1
+CC           = cc
+CFLAGS       = -std=c99
+CFLAGS_riscv = -march=rv32ima_zicsr -mabi=ilp32 -Wl,--gc-sections -ffunction-sections -fdata-sections -fdiagnostics-show-option
+LDFLAGS      = -nostdlib -lc -lgcc
+INCLUDE      = -Ilibrary -Ilibrary/elf -Ilibrary/file -Ilibrary/libc -Ilibrary/syscall
+DEBUG_FLAGS  = --source --all-headers --demangle --line-numbers --wide
 
-SYSAPP_ELFS = $(patsubst %.c, $(RELEASE)/%.elf, $(notdir $(wildcard apps/system/*.c)))
-USRAPP_ELFS = $(patsubst %.c, $(RELEASE)/user/%.elf, $(notdir $(wildcard apps/user/*.c)))
+SYSAPP_ELFS  = $(patsubst %.c, $(RELEASE)/%.elf, $(notdir $(wildcard apps/system/*.c)))
+USRAPP_ELFS  = $(patsubst %.c, $(RELEASE)/user/%.elf, $(notdir $(wildcard apps/user/*.c)))
 
 egos: $(USRAPP_ELFS) $(SYSAPP_ELFS) $(RELEASE)/egos.elf
 
 $(RELEASE)/egos.elf: $(EGOS_DEPS)
 	@echo "$(YELLOW)-------- Compile EGOS --------$(END)"
-	$(RISCV_CC) $(CFLAGS) $(INCLUDE) -DKERNEL $(filter %.s, $(wildcard $^)) $(filter %.c, $(wildcard $^)) -Tlibrary/elf/egos.lds $(LDFLAGS) -o $@
+	$(RISCV_CC) $(CFLAGS_riscv) $(INCLUDE) -DKERNEL $(filter %.s, $(wildcard $^)) $(filter %.c, $(wildcard $^)) -Tlibrary/elf/egos.lds $(LDFLAGS) -o $@
 	@$(OBJDUMP) $(DEBUG_FLAGS) $@ > $(DEBUG)/egos.lst
 
 $(SYSAPP_ELFS): $(RELEASE)/%.elf : apps/system/%.c $(APPS_DEPS)
 	@echo "Compile app$(CYAN)" $(patsubst %.c, %, $(notdir $<)) "$(END)=>" $@
-	@$(RISCV_CC) $(CFLAGS) $(INCLUDE) -DFILESYS=$(FILESYS) -DKERNEL -Iapps apps/app.s $(filter %.c, $(wildcard $^)) -Tlibrary/elf/app.lds $(LDFLAGS) -o $@
+	@$(RISCV_CC) $(CFLAGS_riscv) $(INCLUDE) -DFILESYS=$(FILESYS) -DKERNEL -Iapps apps/app.s $(filter %.c, $(wildcard $^)) -Tlibrary/elf/app.lds $(LDFLAGS) -o $@
 	@$(OBJDUMP) $(DEBUG_FLAGS) $@ > $(patsubst %.c, $(DEBUG)/%.lst, $(notdir $<))
 
 $(USRAPP_ELFS): $(RELEASE)/user/%.elf : apps/user/%.c $(APPS_DEPS)
 	@mkdir -p $(DEBUG) $(RELEASE) $(RELEASE)/user
 	@echo "Compile app$(CYAN)" $(patsubst %.c, %, $(notdir $<)) "$(END)=>" $@
-	@$(RISCV_CC) $(CFLAGS) $(INCLUDE) -Iapps apps/app.s $(filter %.c, $(wildcard $^)) -Tlibrary/elf/app.lds $(LDFLAGS) -o $@
+	@$(RISCV_CC) $(CFLAGS_riscv) $(INCLUDE) -Iapps apps/app.s $(filter %.c, $(wildcard $^)) -Tlibrary/elf/app.lds $(LDFLAGS) -o $@
 	@$(OBJDUMP) $(DEBUG_FLAGS) $@ > $(patsubst %.c, $(DEBUG)/%.lst, $(notdir $<))
 
 install: egos
 	@echo "$(GREEN)-------- Create the Disk & BootROM Image --------$(END)"
 	$(OBJCOPY) -O binary $(RELEASE)/egos.elf tools/qemu/egos.bin
-	$(CC) tools/mkfs.c library/file/file$(FILESYS).c -DMKFS -DFILESYS=$(FILESYS) -DCPU_BIN_FILE="\"fpga/vexriscv/vexriscv_$(BOARD)_$(NCORE)core.bin\"" $(INCLUDE) -o tools/mkfs
+	$(CC) $(CFLAGS) tools/mkfs.c library/file/file$(FILESYS).c -DMKFS -DFILESYS=$(FILESYS) -DCPU_BIN_FILE="\"fpga/vexriscv/vexriscv_$(BOARD)_$(NCORE)core.bin\"" $(INCLUDE) -o tools/mkfs
 	cd tools; rm -f disk.img bootROM.bin; ./mkfs
 
 qemu: install

--- a/README.md
+++ b/README.md
@@ -11,18 +11,20 @@ The [EGOS book](https://egos.fun/book/overview.html) contains 9 course projects 
 
 ```shell
 # The cloc utility is used to count the lines of code.
-> cloc egos-2000 --exclude-ext=md,txt,toml,json  # excluding text files
-...
-github.com/AlDanial/cloc v 1.94  T=0.05 s (949.3 files/s, 62349.4 lines/s)
+> cloc egos-2000 --exclude-lang=Markdown,Text,TOML,make   # excluding text files
+      71 text files.
+      49 unique files.
+      60 files ignored.
+
+github.com/AlDanial/cloc v 2.04  T=0.02 s (2506.4 files/s, 194031.9 lines/s)
 -------------------------------------------------------------------------------
 Language                     files          blank        comment           code
 -------------------------------------------------------------------------------
 C                               29            424            578           1595
-C/C++ Header                     9             61             99            257
+C/C++ Header                     9             62            100            260
 Assembly                         3             15             46             94
-make                             1             15              9             54
 -------------------------------------------------------------------------------
-SUM:                            42            515            732           2000 (exactly!)
+SUM:                            41            501            724           1949
 -------------------------------------------------------------------------------
 ```
 

--- a/library/file/inode.h
+++ b/library/file/inode.h
@@ -36,6 +36,11 @@
 #pragma once
 #include "disk.h"
 
+/* Define uint for C99 compatibility */
+#ifndef uint
+typedef unsigned int uint;
+#endif
+
 #define NINODES 128
 typedef struct inode_store* inode_intf;
 


### PR DESCRIPTION
Hello,

I separated this from other pull request (#46) for clarity.

I could not get the `make qemu` or `make install` commands to work on my system due to errors with incompatible pointer types. From what I've gathered, I believe this is/was a compiler warning in certain versions of GCC, but at some point was upgraded to an Error, causing compilation to fail without some sort of intervention.

## Issue:
When issuing either the `make qemu` or `make install`  command in my terminal, the result is a failed compilation with Error "incompatible-pointer-types". Example:

```sh
% make install
-------- Create the Disk & BootROM Image --------
riscv-none-elf-objcopy -O binary build/release/egos.elf tools/qemu/egos.bin
cc tools/mkfs.c library/file/file1.c -DMKFS -DFILESYS=1 -DCPU_BIN_FILE="\"fpga/vexriscv/vexriscv_a7_35t_4core.bin\"" -Ilibrary -Ilibrary/elf -Ilibrary/file -Ilibrary/libc -Ilibrary/syscall -o tools/mkfs
tools/mkfs.c: In function ‘main’:
tools/mkfs.c:91:66: error: initialization of ‘int (*)(struct inode_store *, uint)’ {aka ‘int (*)(struct inode_store *, unsigned int)’} from incompatible pointer type ‘int (*)(void)’ [-Wincompatible-pointer-types]
   91 |                                                       .getsize = getsize,
      |                                                                  ^~~~~~~
tools/mkfs.c:91:66: note: (near initialization for ‘(anonymous).getsize’)
tools/mkfs.c:65:5: note: ‘getsize’ declared here
   65 | int getsize() { return FILE_SYS_DISK_SIZE / BLOCK_SIZE; }
      |     ^~~~~~~
tools/mkfs.c:92:66: error: initialization of ‘int (*)(struct inode_store *, uint,  uint)’ {aka ‘int (*)(struct inode_store *, unsigned int,  unsigned int)’} from incompatible pointer type ‘int (*)(void)’ [-Wincompatible-pointer-types]
   92 |                                                       .setsize = setsize};
      |                                                                  ^~~~~~~
tools/mkfs.c:92:66: note: (near initialization for ‘(anonymous).setsize’)
tools/mkfs.c:67:5: note: ‘setsize’ declared here
   67 | int setsize() { assert(0); }
      |     ^~~~~~~
make: *** [Makefile:61: install] Error 1

```

### My Environment:

![image](https://github.com/user-attachments/assets/f92494ba-0660-4c1e-9012-c64efc868632)

```sh
% which cc
/usr/bin/cc

% ls -la /usr/bin/cc
lrwxrwxrwx 1 root root 3 Apr 27 10:13 /usr/bin/cc -> gcc

% cc --version
cc (GCC) 15.1.1 20250425
Copyright (C) 2025 Free Software Foundation, Inc.
This is free software; see the source for copying conditions.  There is NO
warranty; not even for MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.

% uname -a
Linux zephy 6.15.2-zen1-1-zen #1 ZEN SMP PREEMPT_DYNAMIC Tue, 10 Jun 2025 21:32:14 +0000 x86_64 GNU/Linux

% lsb_release -a
LSB Version:    n/a
Distributor ID: Arch
Description:    Arch Linux
Release:        rolling
Codename:       n/a

% alacritty --version
alacritty 0.15.1 (0c405d53)

% bash --version
GNU bash, version 5.2.37(1)-release (x86_64-pc-linux-gnu)
Copyright (C) 2022 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>

This is free software; you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
```

# Resolution:

My immediate finding in regards to the error with incompatible pointers was in the [GNU GCC docs](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wno-incompatible-pointer-types) to add the `-Wno-incompatible-pointer-types` flag to the appropriate `cc` execution line in the Makefile. **This resolved the issue with no further changes necessary.** However, given that this is now considered a compiler error (see quote below), it made me wonder which C language standard was in use on the project and/or which GCC or other compiler version was in use, but I found no such information in the documentation. I found only a couple of references to ANSI C, C89, and C90 in the code comments.

>     Do not warn when there is a conversion between pointers that have incompatible types. This warning is for cases not covered by -Wno-pointer-sign, which warns for pointer argument passing or assignment with different signedness.
> 
>     By default, in C99 and later dialects of C, GCC treats this issue as an error. The error can be downgraded to a warning using -fpermissive (along with certain other errors), or for this error alone, with -Wno-error=incompatible-pointer-types.
> 
>     This warning is upgraded to an error by -pedantic-errors.

I thought it might be best to be explicit in setting the C standard in the Makefile, which necessitated adding different `CFLAGS` than those supplied to the RISC-V toolchain, so I added a new variable and updated the Makefile as such, setting `CFLAGS = -std=c99` for the `mkfs.c` compilation and renamed the RISC-V variable to `CFLAGS_riscv`.

However, setting C99 as the standard caused new type errors with missing `uint` type, which I found supplied in egos.h but not in inode.h, so I added the duplicate declaration there, as that file requires the uint type and is referenced in mkfs.c.

With these changes, the code now compiles, but the line numbers are slightly skewed, so I also took it upon myself to exclude the Makefile from the `cloc` command in the README.md file to keep the lines of code below 2000 (it's 2005 with the Makefile included).


**Lastly:**
I hope this is helpful!  If the PR isn't useful, I would at least like to know or help contribute to the documentation in some form, so it is clearer which versions of C and GCC are actually required (or used by the core developers). Coming into this as a relative newbie with C and Makefiles, I had a bit of trouble getting past the USAGES.md file, but thankfully I'm there now and I wanted to at least share my issues and my solutions for posterity.

