### PR TITLE
Fix incompatible pointer types in mkfs.c and sys_file.c

### DIFF
--- a/apps/system/sys_file.c
+++ b/apps/system/sys_file.c
@@ -10,9 +10,9 @@
 #include "inode.h"
 #include <string.h>
 
-static int getsize() { return FILE_SYS_DISK_SIZE / BLOCK_SIZE; }
+static int getsize(inode_intf bs, uint ino) { return FILE_SYS_DISK_SIZE / BLOCK_SIZE; }
 
-static int setsize() { FATAL("disk: cannot set size"); }
+static int setsize(inode_intf bs, uint ino, uint newsize) { FATAL("disk: cannot set size"); }
 
 static int read(inode_intf bs, uint ino, uint offset, block_t* block) {
     earth->disk_read(FILE_SYS_DISK_START + offset, 1, block->bytes);

--- a/tools/mkfs.c
+++ b/tools/mkfs.c
@@ -62,9 +62,9 @@ int load_file(char* file_name, char* dst) {
     return st.st_size;
 }
 
-int getsize() { return FILE_SYS_DISK_SIZE / BLOCK_SIZE; }
+int getsize(inode_intf bs, uint ino) { return FILE_SYS_DISK_SIZE / BLOCK_SIZE; }
 
-int setsize() { assert(0); }
+int setsize(inode_intf bs, uint ino, uint newsize) { assert(0); }
 
 int ramread(inode_intf bs, uint ino, uint offset, block_t* block) {
     memcpy(block, fs + offset * BLOCK_SIZE, BLOCK_SIZE);


### PR DESCRIPTION
Added the missing parameters to `getsize()` and `setsize()` as requested (See #47 for discovery and discussion).

I can confirm this fix resolves the issue on the Arch Linux system and environment referenced in #47 without the need to set the C language standard in the compiler arguments or change the inode.h header file. The `cloc` output remains the same at 2000 LoC.

