### PR TITLE
Buffer Overflow Bug in Shell

### DIFF
--- a/apps/system/sys_shell.c
+++ b/apps/system/sys_shell.c
@@ -27,7 +27,7 @@ int parse_request(char* buf, struct proc_request* req) {
 int main() {
     CRITICAL("Welcome to the egos-2000 shell!");
 
-    char buf[256] = "cd"; /* Enter the home directory first. */
+    char buf[TERM_BUF_SIZE] = "cd"; /* Enter the home directory first. */
     while (1) {
         struct proc_request req;
         struct proc_reply reply;


### PR DESCRIPTION
### Notes

The shell contains a buffer `char buf[256]` for reading terminal input, but it reads up to `TERM_BUF_SIZE` characters from the keyboard at [these lines](https://github.com/yhzhang0128/egos-2000/blob/main/apps/system/sys_shell.c#L67-L69) (and the shell is [compiled with the `-DKERNEL` flag](https://github.com/yhzhang0128/egos-2000/blob/main/Makefile#L47-L49), so it is reading directly from the UART and bypassing the terminal server): 

`while (term_read(buf, TERM_BUF_SIZE) == 0);`

`TERM_BUF_SIZE` [is set to 512](https://github.com/yhzhang0128/egos-2000/blob/main/library/syscall/servers.h#L39), meaning that if I type more than 256 characters, the shell will keep buffering characters, and its stack will be overwritten.

One solution to this is to reduce `TERM_BUF_SIZE` to 256, but that doesn't really solve the underlying problem, so I instead changed the shell's buffer to be of size `TERM_BUF_SIZE`.

### Testing

**Before Updates to Buffer Size**

```
Test 1:
➜ /home/yunhao clear

➜ /home/yunhao anvurwaivbruwaiovnrwuaoihguriwoangvuweaorivueaiwpnvjurewipanvjerwiavghruwipagjiuwpoagjieuwapjgfiewoapjfviepwavnjiwapvnjripawjviropwajmviropajirwopajvirowapmcfikedwameikdwacmikdowacmeowapfcmeiwaocpjmieapwcjmoieoieieowapfjieowpajviewoapjviweaopvniewaopvjniwaopjgviewoapgjniewaopgjveiwaopjvmiewaopjmvieowpajfieowapjfviewaopfjmveiwaovmwijadeopfjvemiwaopfjvewaiopfjiewaopfjiewaopfgjmeiwaopfjiewaopgjvneiwoapjvgeiwoapvieowapjvgioerwapjgviroewapjgvieroawpgjviowarepgjvmirewaopjgviwoaprjgviwoaperjgviwoaprjvgmiwoapjgviw[INFO] sys_shell: too many arguments or argument too long
➜ /home/yunhao pwd        
/home/yunhao
➜ /home/yunhao ls
[FATAL] excp_entry: kernel got exception 2
```

```
Test 2:
➜ /home/yunhao ls
./     ../     README     
➜ /home/yunhao pwd
/home/yunhao
➜ /home/yunhao cat README
With only 2000 lines of code, egos-2000 implements boot loader, SD card driver, tty driver, virtual memory with page tables, interrupt and exception handling, preemptive scheduler, system call, file system, shell, an Ethernet/UDP demo, several user commands, and the mkfs tool. Moreover, the EGOS book (https://egos.fun) contains 9 course projects.
➜ /home/yunhao jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj[INFO] sys_shell: too many arguments or argument too long
➜ /home/yunhao ls 
[FATAL] excp_entry: kernel got exception 2
```

**After Updates to Buffer Size**
```
Test 1:
➜ /home/yunhao pwd
/home/yunhao
➜ /home/yunhao ls
./     ../     README     
➜ /home/yunhao jfeipwaofjeiwaojfvmeiwavmfdawpogheiwafjeiwaopfjediwopfjcemdwaicfmiadwcfovmewdacfodmveiowapcfjvmaiwocfvdmewioapfjmiaojfmieowafjmeoaiwfmieowafmoiewafmoiwaefjmoiewa;jfmioewajmfowajfmoiwe;ajfmoiewajfoiewajfiopejfiopejqfiopewjqfioepwjq9240pfj48q29pfj842qp9fjioprqwjmfiropwjafprkokx,oipqwjfipowaejiopwjagfiepwahgurieonvioprqkopekoqp[gj[rieq[ogjvnireoqpmfiqponivorpqwmvkor[emqivo[qemiofpeniwqfonuewqiofnuewiqofnuirpwqfcjieqonvujipqrufipqbgnuvripqenubiperqnuipfeniwopqjfniopewqfierowpqfnviroapjfivoprjqigopjqipojgiop43j[INFO] sys_shell: too many arguments or argument too long
➜ /home/yunhao ls
./     ../     README     
➜ /home/yunhao pwd
/home/yunhao
➜ /home/yunhao cat README
With only 2000 lines of code, egos-2000 implements boot loader, SD card driver, tty driver, virtual memory with page tables, interrupt and exception handling, preemptive scheduler, system call, file system, shell, an Ethernet/UDP demo, several user commands, and the mkfs tool. Moreover, the EGOS book (https://egos.fun) contains 9 course projects.
➜ /home/yunhao echo It is fixed
It is fixed 
➜ /home/yunhao
```

```
Test 2:
➜ /home/yunhao jjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjjj[INFO] sys_shell: too many arguments or argument too long
➜ /home/yunhao ls 
./     ../     README     
➜ /home/yunhao pwd
/home/yunhao
➜ /home/yunhao cat README
With only 2000 lines of code, egos-2000 implements boot loader, SD card driver, tty driver, virtual memory with page tables, interrupt and exception handling, preemptive scheduler, system call, file system, shell, an Ethernet/UDP demo, several user commands, and the mkfs tool. Moreover, the EGOS book (https://egos.fun) contains 9 course projects.
➜ /home/yunhao echo it is fixed
it is fixed 
➜ /home/yunhao nurewipavgnrjiwaopvjmriawopvmreiwagvmriwao;jmvifkeo;arjpwmvio;ewjqfvmioqpj3fgvier4opqw3gjvirwq3opgj4iq3wipg9jrewiqovgjmwraeov;mreiakvoirejgioak;mnrlhiokpal;mnjiopkl;,kmnjlhujiklmnjbhgvjftryguiopklmnjbhvgncfdretyi78uipokjnbhvgcfdxserwt56t78ouijlhbgvcfdxsret45678u90op[l';kjnbhvgncfdrest4y56789i0oplkjnbhgvcfdsfertyuiokljhbgvcfbdxserr5t6y7u8iokjhgfcdgrestr4567y8uikjhgjfhtdrge456789ipolkjhbgvcfdxgsert8ouipkljnbhvgcfdxgserty7oipkl;jgiroepwjgiroepwgjrieopwgjirpoewgjmriewopgjireopwgjreiowpgjreipwogjreipwogjriepowg[INFO] sys_shell: too many arguments or argument too long
➜ /home/yunhao echo It is fixed!
It is fixed! 
➜ /home/yunhao
```

### Next Steps

On an unrelated note, I was wondering if it may be a good idea to update `LOG` by [also making its buffer](https://github.com/yhzhang0128/egos-2000/blob/main/library/libc/print.c#L40) `TERM_BUF_SIZE`, but I realized that `LOG` can be called from anywhere (not just shell), so the most robust solution seems to be to use `malloc`. Would be interesting to see if there's a solution that doesn't use `malloc`